### PR TITLE
enabled match_body object indexing

### DIFF
--- a/so-elastalert/Dockerfile
+++ b/so-elastalert/Dockerfile
@@ -77,6 +77,9 @@ RUN yum update -y && \
 
 WORKDIR ${ELASTALERT_HOME}
 
+# Copy over Elastalert mappings
+COPY ./files/elastalert.json ./files/past_elastalert.json elastalert/es_mappings/6/
+
 # Install Elastalert.
 RUN python setup.py install; \
 

--- a/so-elastalert/files/elastalert.json
+++ b/so-elastalert/files/elastalert.json
@@ -1,0 +1,26 @@
+{
+  "properties": {
+    "rule_name": {
+      "type": "keyword"
+    },
+    "@timestamp": {
+      "type": "date",
+      "format": "dateOptionalTime"
+    },
+    "alert_time": {
+      "type": "date",
+      "format": "dateOptionalTime"
+    },
+    "match_time": {
+      "type": "date",
+      "format": "dateOptionalTime"
+    },
+    "match_body": {
+      "type": "object",
+      "enabled": "true"
+    },
+    "aggregate_id": {
+      "type": "keyword"
+    }
+  }
+}

--- a/so-elastalert/files/past_elastalert.json
+++ b/so-elastalert/files/past_elastalert.json
@@ -1,0 +1,18 @@
+{
+  "properties": {
+    "rule_name": {
+      "type": "keyword"
+    },
+    "match_body": {
+      "type": "object",
+      "enabled": "true"
+    },
+    "@timestamp": {
+      "type": "date",
+      "format": "dateOptionalTime"
+    },
+    "aggregate_id": {
+      "type": "keyword"
+    }
+  }
+}


### PR DESCRIPTION
Allows `match_body` object (and resultant properties) to be indexed in Elasticsearch, so it/they can be filtered on in dashboards, and used in visualizations.

Related to: https://github.com/Security-Onion-Solutions/security-onion/issues/1500